### PR TITLE
GitHub Build Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 I mean... Everyone wants to build a scheduler, right?
 
+![Build Passing](https://github.com/tylerangelier/spring-quartz-scheduler-oracle-db/actions/workflows/gradle.yml/badge.svg)
+
 # Usage
 
 Probably none. Application used to prove out Spring Scheduler using Quartz with a persistence tier


### PR DESCRIPTION
I mean why do the work of adding a CI build if you can't show it off?